### PR TITLE
New NearFieldBadgeID record field to handle new card scanning

### DIFF
--- a/cmd/qm/main.go
+++ b/cmd/qm/main.go
@@ -216,6 +216,7 @@ func main() {
 			&patronRecord.OtherStatus,
 			&patronRecord.OtherTypeCode,
 			&patronRecord.StudentDegreeEarned,
+			&patronRecord.NearFieldBadgeID,
 		)
 		if scanErr != nil {
 			cfg.Log.Error().Err(scanErr).Msg("failed to retrieve patron record")

--- a/contrib/qm/config.example.toml
+++ b/contrib/qm/config.example.toml
@@ -90,7 +90,8 @@ SELECT
     student_type,
     Other_status,
     Other_type_code,
-    Student_degree_earned
+    Student_degree_earned,
+    NearFieldBadgeID
 FROM
     library_patrons
 WHERE

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -60,7 +60,8 @@ func (r LibraryPatronRecord) String() string {
 			"StudentType: %v, "+
 			"OtherStatus: %v, "+
 			"OtherTypeCode: %v, "+
-			"StudentDegreeEarned: %v"+
+			"StudentDegreeEarned: %v, "+
+			"NearFieldBadgeID: %v"+
 			" }",
 		r.GIDStatus.String,
 		r.GID.String,
@@ -102,6 +103,7 @@ func (r LibraryPatronRecord) String() string {
 		r.OtherStatus.String,
 		r.OtherTypeCode.String,
 		r.StudentDegreeEarned.String,
+		r.NearFieldBadgeID.String,
 	)
 
 }
@@ -269,7 +271,9 @@ func (r *LibraryPatronRecord) padEmpty() {
 	if r.StudentDegreeEarned.Valid && r.StudentDegreeEarned.String == "" {
 		r.StudentDegreeEarned.String = " "
 	}
-
+	if r.NearFieldBadgeID.Valid && r.NearFieldBadgeID.String == "" {
+		r.NearFieldBadgeID.String = " "
+	}
 }
 
 // CSV produces a patron record in a pipe delimited, view_extract.txt file
@@ -291,7 +295,7 @@ func (r LibraryPatronRecord) CSV() string {
 	// field values with a single space.
 	r.padEmpty()
 
-	outputRecordTmpl := "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n"
+	outputRecordTmpl := "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n"
 
 	return fmt.Sprintf(
 		outputRecordTmpl,
@@ -335,6 +339,7 @@ func (r LibraryPatronRecord) CSV() string {
 		r.OtherStatus.String,
 		r.OtherTypeCode.String,
 		r.StudentDegreeEarned.String,
+		r.NearFieldBadgeID.String,
 	)
 }
 

--- a/internal/meta/types.go
+++ b/internal/meta/types.go
@@ -51,4 +51,5 @@ type LibraryPatronRecord struct {
 	OtherStatus               sql.NullString `arg:"-"`
 	OtherTypeCode             sql.NullString `arg:"-"`
 	StudentDegreeEarned       sql.NullString `arg:"-"`
+	NearFieldBadgeID          sql.NullString `arg:"-"`
 }


### PR DESCRIPTION
Updating handling for the new badges. Using a more generic internal name for that field.

I chose "NearFieldBadgeID" because I believe we may be getting additional optional related fields later. This field is specific to our ID badge, a future field may be "NearFieldMobileID" when this option comes to mobile devices.
