### PR TITLE
Add fields for NearField scanning for Iphone, Iwatch, Android

### DIFF
--- a/cmd/qm/main.go
+++ b/cmd/qm/main.go
@@ -217,6 +217,15 @@ func main() {
 			&patronRecord.OtherTypeCode,
 			&patronRecord.StudentDegreeEarned,
 			&patronRecord.NearFieldBadgeID,
+			&patronRecord.NearFieldIphoneID,
+			&patronRecord.NearFieldIphoneExp,
+			&patronRecord.NearFieldIphoneLost,
+			&patronRecord.NearFieldIwatchID,
+			&patronRecord.NearFieldIwatchExp,
+			&patronRecord.NearFieldIwatchLost,
+			&patronRecord.NearFieldAndroidID,
+			&patronRecord.NearFieldAndroidExp,
+			&patronRecord.NearFieldAndroidLost,
 		)
 		if scanErr != nil {
 			cfg.Log.Error().Err(scanErr).Msg("failed to retrieve patron record")

--- a/cmd/qm/main_test.go
+++ b/cmd/qm/main_test.go
@@ -114,7 +114,16 @@ SELECT
     Other_status,
     Other_type_code,
     Student_degree_earned,
-    NearFieldBadgeID
+    NearFieldBadgeID,
+    NearFieldIphoneID,
+    NearFieldIphoneExp,
+    NearFieldIphoneLost,
+    NearFieldIwatchID,
+    NearFieldIwatchExp,
+    NearFieldIwatchLost,
+    NearFieldAndroidID,
+    NearFieldAndroidExp,
+    NearFieldAndroidLost    
 FROM
     library_patrons
 WHERE

--- a/contrib/qm/config.example.toml
+++ b/contrib/qm/config.example.toml
@@ -91,7 +91,16 @@ SELECT
     Other_status,
     Other_type_code,
     Student_degree_earned,
-    NearFieldBadgeID
+    NearFieldBadgeID,
+    NearFieldIphoneID,
+    NearFieldIphoneExp,
+    NearFieldIphoneLost,
+    NearFieldIwatchID,
+    NearFieldIwatchExp,
+    NearFieldIwatchLost,
+    NearFieldAndroidID,
+    NearFieldAndroidExp,
+    NearFieldAndroidLost    
 FROM
     library_patrons
 WHERE

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -61,7 +61,16 @@ func (r LibraryPatronRecord) String() string {
 			"OtherStatus: %v, "+
 			"OtherTypeCode: %v, "+
 			"StudentDegreeEarned: %v, "+
-			"NearFieldBadgeID: %v"+
+			"NearFieldBadgeID: %v, "+
+			"NearFieldIphoneID: %v, "+
+			"NearFieldIphoneExp: %v, "+
+			"NearFieldIphoneLost: %v, "+
+			"NearFieldIwatchID: %v, "+
+			"NearFieldIwatchExp: %v, "+
+			"NearFieldIwatchLost: %v, "+
+			"NearFieldAndroidID: %v, "+
+			"NearFieldAndroidExp: %v, "+
+			"NearFieldAndroidLost: %v"+
 			" }",
 		r.GIDStatus.String,
 		r.GID.String,
@@ -104,6 +113,15 @@ func (r LibraryPatronRecord) String() string {
 		r.OtherTypeCode.String,
 		r.StudentDegreeEarned.String,
 		r.NearFieldBadgeID.String,
+		r.NearFieldIphoneID.String,
+		r.NearFieldIphoneExp.String,
+		r.NearFieldIphoneLost.String,
+		r.NearFieldIwatchID.String,
+		r.NearFieldIwatchExp.String,
+		r.NearFieldIwatchLost.String,
+		r.NearFieldAndroidID.String,
+		r.NearFieldAndroidExp.String,
+		r.NearFieldAndroidLost.String,
 	)
 
 }
@@ -274,6 +292,42 @@ func (r *LibraryPatronRecord) padEmpty() {
 	if r.NearFieldBadgeID.Valid && r.NearFieldBadgeID.String == "" {
 		r.NearFieldBadgeID.String = " "
 	}
+
+	if r.NearFieldIphoneID.Valid && r.NearFieldIphoneID.String == "" {
+		r.NearFieldIphoneID.String = " "
+	}
+
+	if r.NearFieldIphoneExp.Valid && r.NearFieldIphoneExp.String == "" {
+		r.NearFieldIphoneExp.String = " "
+	}
+
+	if r.NearFieldIphoneLost.Valid && r.NearFieldIphoneLost.String == "" {
+		r.NearFieldIphoneLost.String = " "
+	}
+
+	if r.NearFieldIwatchID.Valid && r.NearFieldIwatchID.String == "" {
+		r.NearFieldIwatchID.String = " "
+	}
+
+	if r.NearFieldIwatchExp.Valid && r.NearFieldIwatchExp.String == "" {
+		r.NearFieldIwatchExp.String = " "
+	}
+
+	if r.NearFieldIwatchLost.Valid && r.NearFieldIwatchLost.String == "" {
+		r.NearFieldIwatchLost.String = " "
+	}
+
+	if r.NearFieldAndroidID.Valid && r.NearFieldAndroidID.String == "" {
+		r.NearFieldAndroidID.String = " "
+	}
+
+	if r.NearFieldAndroidExp.Valid && r.NearFieldAndroidExp.String == "" {
+		r.NearFieldAndroidExp.String = " "
+	}
+
+	if r.NearFieldAndroidLost.Valid && r.NearFieldAndroidLost.String == "" {
+		r.NearFieldAndroidLost.String = " "
+	}
 }
 
 // CSV produces a patron record in a pipe delimited, view_extract.txt file
@@ -295,7 +349,7 @@ func (r LibraryPatronRecord) CSV() string {
 	// field values with a single space.
 	r.padEmpty()
 
-	outputRecordTmpl := "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n"
+	outputRecordTmpl := "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n"
 
 	return fmt.Sprintf(
 		outputRecordTmpl,
@@ -340,6 +394,15 @@ func (r LibraryPatronRecord) CSV() string {
 		r.OtherTypeCode.String,
 		r.StudentDegreeEarned.String,
 		r.NearFieldBadgeID.String,
+		r.NearFieldIphoneID.String,
+		r.NearFieldIphoneExp.String,
+		r.NearFieldIphoneLost.String,
+		r.NearFieldIwatchID.String,
+		r.NearFieldIwatchExp.String,
+		r.NearFieldIwatchLost.String,
+		r.NearFieldAndroidID.String,
+		r.NearFieldAndroidExp.String,
+		r.NearFieldAndroidLost.String,
 	)
 }
 

--- a/internal/meta/types.go
+++ b/internal/meta/types.go
@@ -52,4 +52,13 @@ type LibraryPatronRecord struct {
 	OtherTypeCode             sql.NullString `arg:"-"`
 	StudentDegreeEarned       sql.NullString `arg:"-"`
 	NearFieldBadgeID          sql.NullString `arg:"-"`
+	NearFieldIphoneID         sql.NullString `arg:"-"`
+	NearFieldIphoneExp        sql.NullString `arg:"-"`
+	NearFieldIphoneLost       sql.NullString `arg:"-"`
+	NearFieldIwatchID         sql.NullString `arg:"-"`
+	NearFieldIwatchExp        sql.NullString `arg:"-"`
+	NearFieldIwatchLost       sql.NullString `arg:"-"`
+	NearFieldAndroidID        sql.NullString `arg:"-"`
+	NearFieldAndroidExp       sql.NullString `arg:"-"`
+	NearFieldAndroidLost      sql.NullString `arg:"-"`
 }


### PR DESCRIPTION
Added support for 9 new fields in the query-meta data pull.
These are the ID, expiration date, and is_lost flag for three new device types: Iphone, Iwatch, Android
