### PR TITLE
Ignore false-positive gosec G307 linting errors

### DIFF
--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -27,6 +27,9 @@ func (c *Config) loadConfigFile(configFile string) error {
 		return err
 	}
 
+	// #nosec G307
+	// Believed to be a false-positive from recent gosec release
+	// https://github.com/securego/gosec/issues/714
 	defer func() {
 		if err := fh.Close(); err != nil {
 			// Ignore "file already closed" errors


### PR DESCRIPTION
Issues reported after upgrading golangci-lint to v1.43.0.
gosec was updated in that version from v2.8.1 to v2.9.1.

fixes atc0005/query-meta#61
refs golangci/golangci-lint#2299