### PR TITLE
Add missing cmd doc file

### DIFF
--- a/cmd/qm/doc.go
+++ b/cmd/qm/doc.go
@@ -1,0 +1,12 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/query-meta
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Go-based tooling to process patron records from the Meta Microsoft SQL
+// Server database. The qm binary provided by this project is intended to
+// replace the existing query_meta.php script used to retrieve patron records
+// from Meta and write out a pipe-delimited CSV file for further processing.
+package main


### PR DESCRIPTION
Add "package" doc file to resolve revive `package-comment` linting error surfaced by recent linter update.