### PR TITLE
Update Makefile and GitHub Actions Workflows

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -48,13 +48,17 @@ jobs:
           rm -vf .golangci.yml
 
       - name: Run golangci-lint using container-provided config file settings
-        run: golangci-lint run -v
+        run: |
+          golangci-lint --version
+          golangci-lint run
 
       # This is the very latest stable version of staticcheck provided by the
       # atc0005/go-ci container. The version included with golangci-lint often
       # lags behind the official stable releases.
       - name: Run staticcheck
-        run: staticcheck $(go list -mod=vendor ./... | grep -v /vendor/)
+        run: |
+          staticcheck --version
+          staticcheck $(go list -mod=vendor ./... | grep -v /vendor/)
 
   test_code:
     name: Run tests

--- a/.github/workflows/lint-and-test-only.yml
+++ b/.github/workflows/lint-and-test-only.yml
@@ -33,7 +33,30 @@ jobs:
           rm -vf .golangci.yml
 
       - name: Run golangci-lint using container-provided config file settings
-        run: golangci-lint run -v
+        run: |
+          golangci-lint --version
+          golangci-lint run
 
       - name: Run all tests
         run: go test -mod=vendor -v ./...
+
+  go_mod_changes:
+    name: Look for uncommitted Go module changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: ghcr.io/atc0005/go-ci:go-ci-lint-only
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: go mod tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod
+
+      - name: go mod vendor
+        run: |
+          go mod vendor
+          git diff --exit-code

--- a/.github/workflows/lint-docker-files.yml
+++ b/.github/workflows/lint-docker-files.yml
@@ -5,7 +5,7 @@
 # Licensed under the MIT License. See LICENSE file in the project root for
 # full license information.
 
-name: Linting
+name: Dockerfiles Linting
 
 # Run builds for Pull Requests (new, updated)
 # `synchronized` seems to equate to pushing new commits to a linked branch
@@ -28,4 +28,5 @@ jobs:
 
       - name: Run hadolint against all Dockerfile files
         run: |
+          hadolint --version
           hadolint dependabot/docker/go/Dockerfile

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -28,10 +28,12 @@ jobs:
         with:
           node-version: "lts/*"
 
+      # https://github.com/igorshubovych/markdownlint-cli
       - name: Install Markdown linting tools
         run: |
           npm install markdownlint --save-dev
           npm install -g markdownlint-cli
+          echo "markdownlint version: $(markdownlint --version)"
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,15 +19,15 @@ linters:
     - depguard
     - dogsled
     - dupl
+    - exportloopref
     - goconst
     - gocritic
     - gofmt
     - goimports
-    - golint
     - gosec
     - maligned
     - misspell
     - prealloc
-    - scopelint
+    - revive
     - stylecheck
     - unconvert

--- a/Makefile
+++ b/Makefile
@@ -120,9 +120,11 @@ linting:
 	@go vet -mod=vendor $(shell go list -mod=vendor ./... | grep -v /vendor/)
 
 	@echo "Running golangci-lint ..."
+	@golangci-lint --version
 	@golangci-lint run
 
 	@echo "Running staticcheck ..."
+	@staticcheck --version
 	@staticcheck $(shell go list -mod=vendor ./... | grep -v /vendor/)
 
 	@echo "Finished running linting checks"


### PR DESCRIPTION
- echo hadolint version
- echo golangci-lint version
- echo staticcheck version
- echo markdownlint-cli version
- add `go_mod_changes` job to test for uncommitted `go mod tidy` and `go mod vendor` changes
- update repo-bundled golangci-lint configuration to replace (most) deprecated linters
  - `golint` to `revive`
  - `scopelint` to `exportloopref`