### PR TITLE
GHAW: Emit markdownlint version before running

### DIFF
--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -46,4 +46,5 @@ jobs:
         # potential linting issues in bundled documentation to fail linting CI
         # runs for *our* documentation
         run: |
+          echo "markdownlint version: $(markdownlint --version)"
           markdownlint '**/*.md' --ignore node_modules --ignore vendor


### PR DESCRIPTION
Emit markdownlint version at runtime in addition to
after installing the tool.