### PR TITLE
Remove deploy logic from postinstall scripts

### DIFF
--- a/packages/dev/scripts/deb/postinstall.sh
+++ b/packages/dev/scripts/deb/postinstall.sh
@@ -17,8 +17,6 @@ project_releases="${project_repo}/releases"
 project_issues="${project_repo}/issues"
 project_discussions="${project_repo}/discussions"
 
-plugin_name=""
-plugin_path="/usr/lib/nagios/plugins"
 
 echo
 echo "Thank you for installing packages provided by the ${project_fq_name} project!"

--- a/packages/dev/scripts/rpm/postinstall.sh
+++ b/packages/dev/scripts/rpm/postinstall.sh
@@ -17,9 +17,6 @@ project_releases="${project_repo}/releases"
 project_issues="${project_repo}/issues"
 project_discussions="${project_repo}/discussions"
 
-plugin_name=""
-plugin_path="/usr/lib64/nagios/plugins"
-
 
 echo
 echo "Thank you for installing packages provided by the ${project_fq_name} project!"

--- a/packages/stable/scripts/deb/postinstall.sh
+++ b/packages/stable/scripts/deb/postinstall.sh
@@ -17,8 +17,6 @@ project_releases="${project_repo}/releases"
 project_issues="${project_repo}/issues"
 project_discussions="${project_repo}/discussions"
 
-plugin_name=""
-plugin_path="/usr/lib/nagios/plugins"
 
 echo
 echo "Thank you for installing packages provided by the ${project_fq_name} project!"

--- a/packages/stable/scripts/rpm/postinstall.sh
+++ b/packages/stable/scripts/rpm/postinstall.sh
@@ -17,10 +17,6 @@ project_releases="${project_repo}/releases"
 project_issues="${project_repo}/issues"
 project_discussions="${project_repo}/discussions"
 
-plugin_name=""
-plugin_path="/usr/lib64/nagios/plugins"
-
-
 
 echo
 echo "Thank you for installing packages provided by the ${project_fq_name} project!"


### PR DESCRIPTION
This project is not providing plugins, so remove that logic to prevent RPM installation issues.